### PR TITLE
fix: move zod from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@zereight/mcp-gitlab",
-  "version": "1.0.46",
+  "name": "@arm5556/gitlab-mcp-ai",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@zereight/mcp-gitlab",
-      "version": "1.0.46",
+      "name": "@arm5556/gitlab-mcp-ai",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.8.0",
@@ -16,15 +16,15 @@
         "https-proxy-agent": "^7.0.6",
         "node-fetch": "^3.3.2",
         "socks-proxy-agent": "^8.0.5",
+        "zod": "^3.24.2",
         "zod-to-json-schema": "^3.23.5"
       },
       "bin": {
-        "mcp-gitlab": "build/index.js"
+        "gitlab-mcp-ai": "build/src/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.13.10",
-        "typescript": "^5.8.2",
-        "zod": "^3.24.2"
+        "typescript": "^5.8.2"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2",
     "socks-proxy-agent": "^8.0.5",
+    "zod": "^3.24.2",
     "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",
-    "typescript": "^5.8.2",
-    "zod": "^3.24.2"
+    "typescript": "^5.8.2"
   }
 }


### PR DESCRIPTION
Zod is used extensively at runtime for schema validation throughout the codebase. Having it as a devDependency could cause runtime errors when the package is installed in production environments.

🤖 Generated with [Claude Code](https://claude.ai/code)